### PR TITLE
Inintialize covariances in GraftImuTopic

### DIFF
--- a/src/GraftImuTopic.cpp
+++ b/src/GraftImuTopic.cpp
@@ -36,6 +36,11 @@
 
 GraftImuTopic::GraftImuTopic()
 {
+  for( int i=0; i<9; i++ ) {
+    orientation_covariance_[i] = 0.0;
+  	angular_velocity_covariance_[i] = 0.0;
+    linear_acceleration_covariance_[i] = 0.0;
+  }
 }
 
 

--- a/src/GraftOdometryTopic.cpp
+++ b/src/GraftOdometryTopic.cpp
@@ -36,6 +36,10 @@
 GraftOdometryTopic::GraftOdometryTopic():
     absolute_pose_(false), delta_pose_(false), use_velocities_(false), timeout_(1.0)
 {
+  for( int i=0; i<36; i++ ) {
+    pose_covariance_[i] = 0.0;
+    twist_covariance_[i] = 0.0;
+  }
 }
 
 


### PR DESCRIPTION
On my system, I was seeing cases where the UKF diverged about 50% of the
time during the first updated, because the override covariances aren't
initialized, and would occasionally have values like 1.48947e+195
