### PR TITLE
add no_delay parameter

### DIFF
--- a/src/GraftParameterManager.cpp
+++ b/src/GraftParameterManager.cpp
@@ -257,8 +257,17 @@ void GraftParameterManager::loadParameters(
         odom->setName(topic_name);
         topics.push_back(odom);
 
+        // Should we specify nodelay so that packets arrive without delay
+        ros::TransportHints hints;
+        bool tcp_nodelay;
+        if (tnh.getParam("no_delay", tcp_nodelay))
+        {
+          if (tcp_nodelay)
+            hints.tcpNoDelay();
+        }
+
         // Subscribe to topic
-        ros::Subscriber sub = n_.subscribe(full_topic, queue_size_, &GraftOdometryTopic::callback, odom);
+        ros::Subscriber sub = n_.subscribe(full_topic, queue_size_, &GraftOdometryTopic::callback, odom, hints);
         subs.push_back(sub);
 
         // Parse rest of parameters
@@ -273,13 +282,22 @@ void GraftParameterManager::loadParameters(
           continue;
         }
 
-        // Create Odometry object
+        // Create Imu object
         boost::shared_ptr<GraftImuTopic> imu(new GraftImuTopic());
         imu->setName(topic_name);
         topics.push_back(imu);
 
+        // Should we specify nodelay so that packets arrive without delay
+        ros::TransportHints hints;
+        bool tcp_nodelay;
+        if (tnh.getParam("no_delay", tcp_nodelay))
+        {
+          if (tcp_nodelay)
+            hints.tcpNoDelay();
+        }
+
         // Subscribe to topic
-        ros::Subscriber sub = n_.subscribe(full_topic, queue_size_, &GraftImuTopic::callback, imu);
+        ros::Subscriber sub = n_.subscribe(full_topic, queue_size_, &GraftImuTopic::callback, imu, hints);
         subs.push_back(sub);
 
         // Parse rest of parameters


### PR DESCRIPTION
Recently, when trying to run the filter at higher rates, we've noticed that Odom/Imu timeouts are very frequent. When tracking this down I found that our IMU/odom data were being buffered such that the 100hz data arrived in blocks of 4 packets every 25hz. This PR adds support for selecting tcp_nodelay which disables Nagle algorithm buffering.

In the future we might want to make this the default, for now, I've made it optional
