### PR TITLE
Detect if filter has diverged

### DIFF
--- a/include/graft/GraftUKFAbsolute.h
+++ b/include/graft/GraftUKFAbsolute.h
@@ -91,6 +91,8 @@ class GraftUKFAbsolute{
     double kappa_;
 
     std::vector<boost::shared_ptr<GraftSensor> > topics_;
+
+    bool diverged_;
 };
 
 #endif

--- a/include/graft/GraftUKFAttitude.h
+++ b/include/graft/GraftUKFAttitude.h
@@ -91,6 +91,8 @@ class GraftUKFAttitude{
     double kappa_;
 
     std::vector<boost::shared_ptr<GraftSensor> > topics_;
+
+    bool diverged_;
 };
 
 #endif

--- a/include/graft/GraftUKFVelocity.h
+++ b/include/graft/GraftUKFVelocity.h
@@ -91,6 +91,8 @@ class GraftUKFVelocity{
     double kappa_;
 
     std::vector<boost::shared_ptr<GraftSensor> > topics_;
+
+    bool diverged_;
 };
 
 #endif

--- a/src/GraftUKFAbsolute.cpp
+++ b/src/GraftUKFAbsolute.cpp
@@ -34,7 +34,7 @@
  #include <graft/GraftUKFAbsolute.h>
  #include <ros/console.h>
 
- GraftUKFAbsolute::GraftUKFAbsolute(){
+ GraftUKFAbsolute::GraftUKFAbsolute() : diverged_(false){
 	graft_state_.setZero();
 	graft_state_(3) = 1.0; // Normalize quaternion
 	graft_control_.setZero();
@@ -371,6 +371,9 @@ double GraftUKFAbsolute::predictAndUpdate(){
 	if(topics_.size() == 0 || topics_[0] == NULL){
 		return 0;
 	}
+	if( diverged_ ) {
+		return 0;
+	}
 	ros::Time t = ros::Time::now();
 	double dt = (t - last_update_time_).toSec();
 	if(last_update_time_.toSec() < 0.0001){ // No previous updates
@@ -403,6 +406,32 @@ double GraftUKFAbsolute::predictAndUpdate(){
 	graft_state_.block(3, 0, 4, 1) = unitQuaternion(graft_state_.block(3, 0, 4, 1));
 
 	graft_covariance_ = predicted_covariance - K*predicted_measurement_uncertainty*K.transpose();
+
+	for( int i=0; i<SIZE; i++ ) {
+		for( int j=0; j<SIZE; j++ ) {
+			if( !std::isfinite(graft_covariance_(i, j)) ) {
+				diverged_ = true;
+			}
+		}
+	}
+	if( diverged_ ) {
+		// print offending messages
+		std::stringstream errmsg;
+		errmsg << "Covariance diverged! Offending topics are: ";
+
+		// For each topic
+		for(size_t i = 0; i < topics_.size(); i++){
+			// Get the measurement msg and covariance
+			graft::GraftSensorResidual::ConstPtr meas = topics_[i]->z();
+			if( meas ) {
+				if( i>0 ) errmsg << ", ";
+				errmsg << topics_[i]->getName() << "(";
+				errmsg << *meas << ")";
+			}
+		}
+
+		ROS_ERROR_STREAM(errmsg.str());
+	}
 
 	clearMessages(topics_);
 	return dt;

--- a/src/GraftUKFAbsolute.cpp
+++ b/src/GraftUKFAbsolute.cpp
@@ -430,7 +430,7 @@ double GraftUKFAbsolute::predictAndUpdate(){
 			}
 		}
 
-		ROS_ERROR_STREAM(errmsg.str());
+		ROS_ERROR_STREAM_THROTTLE(5.0, errmsg.str());
 	}
 
 	clearMessages(topics_);


### PR DESCRIPTION
My particular configuration was diverging frequently due to poor configuration, so I added a check for it and some debugging output about the last set of messages the the filter received before it diverged.

This is generally quite useful for spotting bad input data or bad covariances.
